### PR TITLE
CI: bumps up `actions/*-artifact` to v4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -96,7 +96,7 @@ jobs:
       continue-on-error: true
       run: bash ./ci/scripts/collect-bins.sh "${{env.artifact-name}}"
     - name: Upload Aritracts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{env.artifact-name}}.tar.zst
         name: ${{env.artifact-name}}
@@ -132,7 +132,7 @@ jobs:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
       - name: Download artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Decompress
         run: tar xaf ${{env.artifact}}/${{env.artifact}}.tar.zst
       - name: Run Tests

--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,6 @@ workspace
 
 ### https://raw.github.com/github/gitignore/14f8a8b4c51ecc00b18905a95c117954e6c77b9d/Global/VisualStudioCode.gitignore
 
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 *.code-workspace
 
 # Local History for Visual Studio Code
@@ -117,7 +112,7 @@ cabal.project.local~
 ### https://raw.github.com/github/gitignore/e5323759e387ba347a9d50f8b0ddd16502eb71d4/Global/VisualStudioCode.gitignore
 
 .vscode/*
-!.vscode/settings.json
+!.vscode/*.shared.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json


### PR DESCRIPTION
Fix for security vulnerability https://github.com/advisories/GHSA-6q32-hq47-5qq3.